### PR TITLE
fix distorted images in posts

### DIFF
--- a/components/HackCard.js
+++ b/components/HackCard.js
@@ -115,6 +115,8 @@ const HackCard = (props) => {
 
                     .post-body img {
                         max-height: 250px;
+                        max-width: 100%;
+                        width: auto;
                     }
 
                     .post-body p code, .post-body ol li code {


### PR DESCRIPTION
Before:
![grafik](https://user-images.githubusercontent.com/18481195/65981631-d196af80-e479-11e9-8e60-d9d5b3708995.png)

After:
![grafik](https://user-images.githubusercontent.com/18481195/65981606-c17ed000-e479-11e9-9432-7b6d13f0531d.png)
